### PR TITLE
Some upgrades to the install script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,9 @@ RUN apk add bash curl
 
 # Install all versions of solc
 COPY scripts/install_solc.sh /
+COPY scripts/semver.sh /
 RUN bash /install_solc.sh
-RUN rm /install_solc.sh
+RUN rm /install_solc.sh /semver.sh
 # Install the solc-selection script:
 COPY scripts/solc-select /usr/bin/
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,18 +1,56 @@
 #!/bin/bash
 
+PARAMS=""
+while (( "$#" )); do
+  case "$1" in
+    --force)
+        export FORCE=1
+        shift
+        ;;
+    --after)
+      if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+        export SOLC_AFTER=$2
+        shift 2
+      else
+        echo "Error: Argument for $1 is missing" >&2
+        exit 1
+      fi
+      ;;
+    --before)
+      if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+        export SOLC_BEFORE=$2
+        shift 2
+      else
+        echo "Error: Argument for $1 is missing" >&2
+        exit 1
+      fi
+      ;;
+    -*|--*=) # unsupported flags
+      echo "Error: Unsupported flag $1" >&2
+      exit 1
+      ;;
+    *) # preserve positional arguments
+      PARAMS="$PARAMS $1"
+      shift
+      ;;
+  esac
+done
+# set positional arguments in their proper place
+eval set -- "$PARAMS"
+
 OS=$(uname)
 
 #
 # Install locally on Linux
 
-if [ $OS = "Linux" ]; then
+if [[ ${OS} = "Linux" ]]; then
     echo "Detected Linux"
 
     REPO_SCRIPTDIR=`dirname "$0"`
     cd $REPO_SCRIPTDIR
 
     if [ ! -f ./install_linux.sh ]; then
-        echo "Cannot find Linux installation script. If you are installing via Docker - it is unecessary on Linux, instead refer to Linux installation instructions in README.md"
+        echo "Cannot find Linux installation script. If you are installing via Docker - it is unnecessary on Linux, instead refer to Linux installation instructions in README.md"
         exit 1
     fi
 

--- a/scripts/install_solc.sh
+++ b/scripts/install_solc.sh
@@ -98,7 +98,7 @@ function solc_releases {
         page=$((page+1))
     done
 
-    result=$(echo "$result" | sort -rV)
+    result=$(echo "$result" | sort -t. -k 1,1nr -k 2,2nr -k 3,3nr)
     echo "$result"
 }
 

--- a/scripts/install_solc.sh
+++ b/scripts/install_solc.sh
@@ -1,20 +1,117 @@
 #!/bin/bash
 
+source semver.sh
+
+function download {
+    version="$1"
+    url="$2"
+    to="$3"
+
+    curl -s -f -L "$url" -o "$to" && chmod +x "$to"
+
+    if [[ $? -eq 0 ]]; then
+        echo "[+] successfully downloaded solc $version"
+    else
+        echo "[+] failed to download solc $version"
+    fi
+}
+function download_official_release {
+    version="$1"
+    asset_name="$2"
+    target_location="$3"
+
+    download "$version" "https://github.com/ethereum/solidity/releases/download/v${version}/${asset_name}" "$target_location"
+}
+function download_crytic_build {
+    version="$1"
+    target_location="$2"
+
+    download "$version" "https://github.com/crytic/solc/raw/master/linux/amd64/solc-v${version}" "$target_location"
+}
+
+function install_solc_too_old {
+    version="$1"
+    target_location="$2"
+
+    echo "[+] $version is too old, not installing"
+}
+function install_solc_crytic {
+    version="$1"
+    target_location="$2"
+
+    download_crytic_build "$version" "$target_location"
+}
+function install_solc_0_4_10 {
+    version="$1"
+    target_location="$2"
+
+    download_official_release "$version" "solc" "$target_location"
+}
+function install_solc_0_4_11_plus {
+    version="$1"
+    target_location="$2"
+
+    download_official_release "$version" "solc-static-linux" "$target_location"
+}
+
 function install_solc {
-    solc="$SSELECT_INSTALL_DIR/usr/bin/solc-${1}"
-    curl -s -f -L "https://github.com/ethereum/solidity/releases/download/${1}/solc-static-linux" -o "$solc" && chmod +x "$solc" && echo "Installed solc-${1}"
+    version="$1"
+
+    target_location="$SSELECT_INSTALL_DIR/usr/bin/solc-v${version}"
+
+    if [[ -f ${target_location} ]] && [[ ${FORCE} -ne 1 ]]; then
+        echo "[+] ${version} is already installed"
+        return 0
+    fi
+
+    if $(semverLt "$version" "0.4.0"); then
+        install_solc_too_old "$version" "$target_location"
+    elif $(semverLt "$version" "0.4.10"); then
+        install_solc_crytic "$version" "$target_location"
+    elif $(semverLt "$version" "0.4.11"); then
+        install_solc_0_4_10 "$version" "$target_location"
+    else
+        install_solc_0_4_11_plus "$version" "$target_location"
+    fi
+}
+
+function solc_releases_with_page {
+  page="$1"
+
+  curl --silent "https://api.github.com/repos/ethereum/solidity/releases?per_page=100&page=$page" |
+    grep '"tag_name":' |
+    sed -E 's/.*"v([^"]+)".*/\1/'
 }
 
 function solc_releases {
-  curl --silent "https://api.github.com/repos/ethereum/solidity/releases" |
-    grep '"tag_name":' |
-    sed -E 's/.*"([^"]+)".*/\1/'
+    result=""
+
+    page="1"
+    while : ; do
+        tags="$(solc_releases_with_page "$page")"
+        printf -v result '%s%s\n' "$result" "$tags"
+
+        if [[ "$(echo "$tags" | wc -l)" != "100" ]]; then
+            break
+        fi
+
+        page=$((page+1))
+    done
+
+    result=$(echo "$result" | sort -rV)
+    echo "$result"
 }
 
 if [ ! -z "$SSELECT_INSTALL_DIR" ]; then
   echo "Installing solc versions into $SSELECT_INSTALL_DIR/usr/bin"
 fi
 
-for tag in $(solc_releases); do
-    install_solc "$tag" || true
+for release in $(solc_releases); do
+    if [[ ! -z "$SOLC_AFTER" ]] && semverLt "$release" "$SOLC_AFTER"; then
+        break # we can break since the list of releases is sorted
+    fi
+    if [[ ! -z "$SOLC_BEFORE" ]] && ! semverLt "$release" "$SOLC_BEFORE"; then
+        continue # skip until we hit the version we care about
+    fi
+    install_solc "$release" || true
 done

--- a/scripts/semver.sh
+++ b/scripts/semver.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+function semverLt() {
+    left="$1"
+    right="$2"
+
+    left_major=$(echo "$left" | cut -d'.' -f1)
+    right_major=$(echo "$right" | cut -d'.' -f1)
+    if [[ $((left_major > right_major)) -eq 1 ]]; then
+        return 1
+    elif [[ $((left_major < right_major)) -eq 1 ]]; then
+        return 0
+    fi
+
+    left_minor=$(echo "$left" | cut -d'.' -f2)
+    right_minor=$(echo "$right" | cut -d'.' -f2)
+    if [[ $((left_minor > right_minor)) -eq 1 ]]; then
+        return 1
+    elif [[ $((left_minor < right_minor)) -eq 1 ]]; then
+        return 0
+    fi
+
+    left_patch=$(echo "$left" | cut -d'.' -f3)
+    right_patch=$(echo "$right" | cut -d'.' -f3)
+    if [[ $((left_patch >= right_patch)) -eq 1 ]]; then
+        return 1
+    fi
+
+    return 0
+}

--- a/scripts/solc-select
+++ b/scripts/solc-select
@@ -14,7 +14,7 @@ INSTALL_DIR="$SSELECT_INSTALL_DIR/usr/bin"
 VERSION=$1
 
 if [ "$VERSION" = "--list" ] || [ "$VERSION" = "-l" ]; then
-    find "$INSTALL_DIR" -name 'solc-v*' -printf "%f\n" | awk -F'v' '{print $2}' | sort
+    find "$INSTALL_DIR" -name 'solc-v*' -printf "%f\n" | awk -F'v' '{print $2}' | sort -V
     exit 0
 fi
 

--- a/scripts/solc-select
+++ b/scripts/solc-select
@@ -14,7 +14,7 @@ INSTALL_DIR="$SSELECT_INSTALL_DIR/usr/bin"
 VERSION=$1
 
 if [ "$VERSION" = "--list" ] || [ "$VERSION" = "-l" ]; then
-    find "$INSTALL_DIR" -name 'solc-v*' -printf "%f\n" | awk -F'v' '{print $2}' | sort -V
+    find "$INSTALL_DIR" -name 'solc-v*' -printf "%f\n" | awk -F'v' '{print $2}' | sort -t. -k 1,1nr -k 2,2nr -k 3,3nr
     exit 0
 fi
 


### PR DESCRIPTION
Shiny features!

- install all versions starting from 0.4.0 (using some [prebuilt binaries](https://github.com/crytic/solc))
- install a range of versions (use `--after` and `--before`, fixes #28)
- detect if a version is already installed, and if so don't redownload (but you can override it with `--force`)
- sort installed versions by version