### PR TITLE
Adding bash programmable completion of versions with 'solc use [TAB]'

### DIFF
--- a/scripts/completion.sh
+++ b/scripts/completion.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+function _listversions()
+{
+    local cur
+    COMPREPLY=()
+    cur=${COMP_WORDS[COMP_CWORD]}
+    line=${COMP_LINE}
+    case "$line" in
+      *use*)
+         COMPREPLY=($( compgen -W "$(ls ~/.solc-select/usr/bin/ | grep 'solc-v' | cut -d 'v' -f 2)" -- $cur ) )
+    esac
+}
+
+complete -F _listversions solc

--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -16,6 +16,7 @@ fi
 
 bash ./install_solc.sh
 
+
 SOLC_SELECT_SCRIPT="$BIN_DIR/solc-select"
 cp ./solc-select $SOLC_SELECT_SCRIPT
 chmod +x $SOLC_SELECT_SCRIPT
@@ -29,7 +30,10 @@ chmod +x $SOLC_RUNNER_SCRIPT
 SOLC_SCRIPT="$SSELECT_INSTALL_DIR/solc"
 cp ../bin/solc $SOLC_SCRIPT
 
+cp completion.sh $SSELECT_INSTALL_DIR
+
 echo "Installed solc into $SOLC_SCRIPT."
 echo ""
-echo "Add the following line to your .bashrc file:"
+echo "Add the following lines to your .bashrc file:"
 echo "  export PATH=$SSELECT_INSTALL_DIR:\$PATH"
+echo "  source $SELECT_INSTALL_DIR\\completion.sh"


### PR DESCRIPTION
A small addition of bash auto completion to have a more convenient way for selecting the version