### PR TITLE
Fix macOS installation

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -67,10 +67,10 @@ if [ -z "$PREFIX" ]; then
     EXISTING_SOLC_PATH=`which solc`
     if [ $? -ne 0 ]; then
         # solc isn't yet installed
-        EXISTING_SOLC_PATH='/usr/bin/solc'
+        EXISTING_SOLC_PATH='/usr/local/bin/solc'
     fi
 else
-    EXISTING_SOLC_PATH="$PREFIX/bin/solc"
+    EXISTING_SOLC_PATH="$PREFIX/local/bin/solc"
 fi
 
 if [ -f $EXISTING_SOLC_PATH ]; then
@@ -81,6 +81,7 @@ if [ -f $EXISTING_SOLC_PATH ]; then
 fi
 
 finalize () {
+    chmod u+x $EXISTING_SOLC_PATH
     echo "Installed solc to ${EXISTING_SOLC_PATH}"
 }
 


### PR DESCRIPTION
Installation on macOS Catalina fails with following error:
`bash: line 89: /usr/bin/solc: Permission denied`

`sold` is being installed at the path `/usr/bin/solc` which is protected by the system. Recommended path is `/usr/local/bin/solc`. It also requires changing permissions afterwards.

This PR changes installation path to `/usr/local/bin/solc` and updates permissions of `solc` to  755.

I’m far out of my comfort zone on this and I don’t know the repercussions of this change so do with it what you will. Cheers!