### PR TITLE
Support for older solc versions with Linux 

### DIFF
--- a/solc_select/__main__.py
+++ b/solc_select/__main__.py
@@ -21,7 +21,7 @@ def solc_select():
         versions = args.get(INSTALL_VERSIONS)
         if versions == []:
             print("Available versions to install:")
-            for version in sorted(get_installable_versions()):
+            for version in get_installable_versions():
                 print(version)
         else:
             install_artifacts(args.get(INSTALL_VERSIONS))

--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 import os
 import re
@@ -51,11 +52,11 @@ def install_artifacts(versions):
         print(f"Version '{version}' installed.")
 
 def is_older_linux(version):
-    return soliditylang_platform() == 'linux-amd64' and StrictVersion(version) < StrictVersion("0.4.10")
+    return soliditylang_platform() == 'linux-amd64' and StrictVersion(version) <= StrictVersion("0.4.10")
 
 def get_url(version,artifact):
     if is_older_linux(version):
-        return f"https://github.com/crytic/solc/tree/master/linux/amd64/{artifact}"
+        return f"https://raw.githubusercontent.com/crytic/solc/master/linux/amd64/{artifact}"
     else:
         return f"https://binaries.soliditylang.org/{soliditylang_platform()}/{artifact}"
 

--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -28,7 +28,7 @@ def current_version():
     return (version, source)
 
 def installed_versions():
-    return [f.replace('solc-', '') for f in sorted(os.listdir(artifacts_dir))]
+    return [f.replace('solc-', '') for f in sorted(os.listdir(artifacts_dir)) if f.startswith('solc-')]
 
 
 # TODO: accept versions in range

--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -84,7 +84,9 @@ def valid_install_arg(arg):
         return valid_version(arg)
 
 def get_installable_versions():
-    return set(get_available_versions()) - set(installed_versions())
+    installable = list(set(get_available_versions()) - set(installed_versions()))
+    installable.sort(key=StrictVersion)
+    return installable
 
 def get_available_versions():
     url = f"https://binaries.soliditylang.org/{soliditylang_platform()}/list.json"
@@ -97,7 +99,8 @@ def get_available_versions():
 def get_additional_linux_versions():
     if soliditylang_platform() == 'linux-amd64':
         # This is just to be dynamic, but figure out a better way to do this.
-        github_json = urllib.request.urlopen("https://raw.githubusercontent.com/crytic/solc/list-json/linux/amd64/list.json").read()
+        url = "https://raw.githubusercontent.com/crytic/solc/list-json/linux/amd64/list.json"
+        github_json = urllib.request.urlopen(url).read()
         return json.loads(github_json)["releases"]
 
 def soliditylang_platform():

--- a/solc_select/solc_select.py
+++ b/solc_select/solc_select.py
@@ -51,7 +51,7 @@ def install_artifacts(versions):
         print(f"Version '{version}' installed.")
 
 def is_older_linux(version):
-    return soliditylang_platform() == 'linux-amd64' and StrictVersion(version) < StrictVersion("0.4.9")
+    return soliditylang_platform() == 'linux-amd64' and StrictVersion(version) < StrictVersion("0.4.10")
 
 def get_url(version,artifact):
     if is_older_linux(version):
@@ -96,6 +96,7 @@ def get_available_versions():
 
 def get_additional_linux_versions():
     if soliditylang_platform() == 'linux-amd64':
+        # This is just to be dynamic, but figure out a better way to do this.
         github_json = urllib.request.urlopen("https://raw.githubusercontent.com/crytic/solc/list-json/linux/amd64/list.json").read()
         return json.loads(github_json)["releases"]
 


### PR DESCRIPTION
**DRAFT PR**

- Fixes #41 to pull solc versions 0.4.0-0.4.9 from https://github.com/crytic/solc

_Remaining Fixes:_
1. Find a more elegant solution to pulling releases: https://github.com/crytic/solc-select/blob/fix/old-linux-versions/solc_select/solc_select.py#L99-L100
~2. The changes here affect the printing out of remaining versions, where they do not print in order:~ DONE
```
0.4.1
0.4.10
0.4.13
0.4.14
0.4.15
0.4.16
0.4.17
0.4.18
0.4.19
0.4.2
0.4.20
0.4.21
0.4.22
0.4.23
0.4.24
0.4.25
0.4.26
0.4.3
0.4.5
0.4.6
0.5.0
```